### PR TITLE
Fix for 'dlopen failed: cannot locate symbol "stpcpy" referenced by

### DIFF
--- a/external/Android.mk
+++ b/external/Android.mk
@@ -70,7 +70,8 @@ libsqlite3_android_local_src_files_32 := \
 	android-sqlite/android/OldPhoneNumberUtils.cpp \
 	android-sqlite/android/PhoneticStringUtils.cpp \
 	String16_32.cpp \
-	String8_32.cpp 
+	String8_32.cpp \
+	stpcpy.c
 #	android-sqlite/android/PhoneNumberUtilsTest.cpp \
 #	android-sqlite/android/PhoneticStringUtilsTest.cpp \
 
@@ -79,7 +80,8 @@ libsqlite3_android_local_src_files_64 :=  \
 	android-sqlite_lollipop/android/PhoneNumberUtils.cpp \
 	android-sqlite_lollipop/android/OldPhoneNumberUtils.cpp \
 	String16_64.cpp \
-	String8_64.cpp 
+	String8_64.cpp \
+	stpcpy.c
 
 include $(CLEAR_VARS)
 

--- a/external/stpcpy.c
+++ b/external/stpcpy.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include <assert.h>
+#include <stdlib.h>
+
+char * stpcpy(char *dst, char const *src) {
+    size_t src_len = strlen(src);
+    return memcpy(dst, src, src_len) + src_len;
+}


### PR DESCRIPTION
After updated to the latest sdk i started getting 'dlopen failed: cannot locate symbol "stpcpy" referenced by' on older platforms. This patch seems to resolve it on the devices that were getting the error.
